### PR TITLE
Adas1/image tokenization

### DIFF
--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -18,3 +18,17 @@ type ImageBlockParam = {
         data: string;
     };
 };
+
+export async function POST(req: Request) {
+    try {
+        if (!req.headers.get('content-type')?.includes('application/json')) {
+            return Response.json(
+                { error: 'Unsupported content-type. Use application/json.' },
+                { status: 415 }
+            );
+        }
+    } catch (error) {
+        console.error('Image token-counting error:', error);
+        return Response.json({ error: 'Failed to count tokens for image.' }, { status: 500 });
+    }
+}

--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -1,0 +1,6 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5 MiB
+const ALLOWED_MEDIA_TYPES = ['image/png', 'image/jpeg', 'image/webp'] as const;
+type AllowedMediaType = (typeof ALLOWED_MEDIA_TYPES)[number];
+

--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -9,3 +9,12 @@ interface ImagePayload {
   media_type: AllowedMediaType;
   text?: string;
 }
+
+type ImageBlockParam = {
+    type: 'image';
+    source: {
+        type: 'base64';
+        media_type: AllowedMediaType;
+        data: string;
+    };
+};

--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -27,6 +27,27 @@ export async function POST(req: Request) {
                 { status: 415 }
             );
         }
+
+        const body = (await req.json()) as Partial<ImagePayload>;
+        const { image, media_type } = body;
+
+        if (!image) {
+            return Response.json(
+                { error: 'Missing "image" property (base-64 string).' },
+                { status: 400 }
+            );
+        }
+
+        if (!media_type || !ALLOWED_MEDIA_TYPES.includes(media_type)) {
+            return Response.json(
+                {
+                    error: `Unsupported or missing media_type. Allowed types: ${ALLOWED_MEDIA_TYPES.join(
+                        ', '
+                    )}`,
+                },
+                { status: 400 }
+            );
+        }
     } catch (error) {
         console.error('Image token-counting error:', error);
         return Response.json({ error: 'Failed to count tokens for image.' }, { status: 500 });

--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -1,6 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 
-const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5 MiB
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 5 MiB
 const ALLOWED_MEDIA_TYPES = ['image/png', 'image/jpeg', 'image/webp'] as const;
 type AllowedMediaType = (typeof ALLOWED_MEDIA_TYPES)[number];
 

--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -48,6 +48,16 @@ export async function POST(req: Request) {
                 { status: 400 }
             );
         }
+
+        const cleanedBase64 = image.replace(/^data:[^;]+;base64,/, '');
+        const buffer = Buffer.from(cleanedBase64, 'base64');
+
+        if (buffer.length > MAX_IMAGE_BYTES) {
+            return Response.json(
+                { error: `Image exceeds the ${MAX_IMAGE_BYTES / 1024 / 1024} MiB limit.` },
+                { status: 413 }
+            );
+        }
     } catch (error) {
         console.error('Image token-counting error:', error);
         return Response.json({ error: 'Failed to count tokens for image.' }, { status: 500 });

--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -58,6 +58,17 @@ export async function POST(req: Request) {
                 { status: 413 }
             );
         }
+
+        const content: ImageBlockParam[] = [
+            {
+                type: 'image',
+                source: {
+                type: 'base64',
+                media_type,
+                data: cleanedBase64,
+                },
+            },
+        ];
     } catch (error) {
         console.error('Image token-counting error:', error);
         return Response.json({ error: 'Failed to count tokens for image.' }, { status: 500 });

--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -4,3 +4,8 @@ const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5 MiB
 const ALLOWED_MEDIA_TYPES = ['image/png', 'image/jpeg', 'image/webp'] as const;
 type AllowedMediaType = (typeof ALLOWED_MEDIA_TYPES)[number];
 
+interface ImagePayload {
+  image: string;
+  media_type: AllowedMediaType;
+  text?: string;
+}

--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -82,6 +82,8 @@ export async function POST(req: Request) {
                 },
             ],
         });
+
+        return Response.json(count);
     } catch (error) {
         console.error('Image token-counting error:', error);
         return Response.json({ error: 'Failed to count tokens for image.' }, { status: 500 });

--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -69,6 +69,19 @@ export async function POST(req: Request) {
                 },
             },
         ];
+
+        const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+        const count = await anthropic.beta.messages.countTokens({
+            betas: ['token-counting-2024-11-01'],
+            model: 'claude-3-5-sonnet-20241022',
+            messages: [
+                {
+                    role: 'user',
+                    content,
+                },
+            ],
+        });
     } catch (error) {
         console.error('Image token-counting error:', error);
         return Response.json({ error: 'Failed to count tokens for image.' }, { status: 500 });

--- a/components/tokenComponents.tsx
+++ b/components/tokenComponents.tsx
@@ -140,6 +140,16 @@ export const TokenizerInput = () => {
         }
     };
 
+    const removeImage = () => {
+        setImage(null);
+        setImagePreview(null);
+        // Reset file input
+        const fileInput = document.getElementById('image-input') as HTMLInputElement;
+        if (fileInput) {
+            fileInput.value = '';
+        }
+    };
+
     return (
         <>
             <div className="space-y-4 mb-4">

--- a/components/tokenComponents.tsx
+++ b/components/tokenComponents.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { X, Upload, Image as ImageIcon } from 'lucide-react';
 
 // Debounce utility function
 const debounce = <T extends (...args: any[]) => void>(func: T, delay: number) => {
@@ -9,6 +11,11 @@ const debounce = <T extends (...args: any[]) => void>(func: T, delay: number) =>
         timeoutId = setTimeout(() => func(...args), delay);
     };
 };
+
+interface InputData {
+    text: string;
+    image: File | null;
+}
 
 export const TokenizerInput = () => {
     const [text, setText] = useState('');

--- a/components/tokenComponents.tsx
+++ b/components/tokenComponents.tsx
@@ -163,6 +163,68 @@ export const TokenizerInput = () => {
             </div>
             {error && <p className="text-red-500 mb-4">{error}</p>}
             <TokenMetrics tokens={stats.tokens ?? 0} chars={stats.chars} />
+        
+            
+                {/* Image Input */}
+                <div>
+                    <label className="block text-sm font-medium mb-2">Image Input</label>
+                    <div className="flex items-center gap-4">
+                        <div className="relative">
+                            <input
+                                id="image-input"
+                                type="file"
+                                accept="image/*"
+                                onChange={handleImageSelect}
+                                className="hidden"
+                            />
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => document.getElementById('image-input')?.click()}
+                                className="flex items-center gap-2"
+                            >
+                                <Upload size={16} />
+                                Select Image
+                            </Button>
+                        </div>
+                        
+                        {image && (
+                            <div className="flex items-center gap-2">
+                                <ImageIcon size={16} />
+                                <span className="text-sm text-gray-600">{image.name}</span>
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={removeImage}
+                                    className="h-6 w-6 p-0"
+                                >
+                                    <X size={12} />
+                                </Button>
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Image Preview */}
+                    {imagePreview && (
+                        <div className="mt-3">
+                            <img
+                                src={imagePreview}
+                                alt="Preview"
+                                className="max-w-xs max-h-48 rounded-lg border"
+                            />
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {error && <p className="text-red-500 mb-4">{error}</p>}
+            
+            {isLoading && (
+                <p className="text-blue-500 mb-4">Analyzing content...</p>
+            )}
+
+            <TokenMetrics tokens={stats.tokens ?? 0} chars={stats.chars} hasImage={!!image} />
         </>
     );
 };

--- a/components/tokenComponents.tsx
+++ b/components/tokenComponents.tsx
@@ -103,6 +103,8 @@ export const TokenizerInput = () => {
             console.error("Token counting error:", err);
             setError("Failed to analyze text. Please try again.");
             setStats({ tokens: null, chars: text.length }); // Reset tokens but keep character count
+        } finally {
+            setIsLoading(false);
         }
     };
 
@@ -112,6 +114,31 @@ export const TokenizerInput = () => {
     useEffect(() => {
         debouncedHandleAnalyze({ text, image });
     }, [text, debouncedHandleAnalyze]);
+
+    const handleImageSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (file) {
+            if (!file.type.startsWith('image/')) {
+                setError('Please select a valid image file.');
+                return;
+            }
+            const maxSize = 10 * 1024 * 1024; // 10MB
+            if (file.size > maxSize) {
+                setError('Image file is too large. Please select a file smaller than 10MB.');
+                return;
+            }
+
+            setImage(file);
+            setError(null);
+
+            // Create preview
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                setImagePreview(e.target?.result as string);
+            };
+            reader.readAsDataURL(file);
+        }
+    };
 
     return (
         <>

--- a/components/tokenComponents.tsx
+++ b/components/tokenComponents.tsx
@@ -232,17 +232,22 @@ export const TokenizerInput = () => {
 interface TokenMetricsProps {
     tokens: number;
     chars: number;
+    hasImage: boolean;
 }
 
-export const TokenMetrics = ({ tokens, chars }: TokenMetricsProps) => (
+export const TokenMetrics = ({ tokens, chars, hasImage }: TokenMetricsProps) => (
     <div className="flex gap-8">
         <div className="space-y-1">
             <h2 className="leading-none font-black">Tokens</h2>
             <p className="text-4xl font-thin">{tokens}</p>
+            {hasImage && (
+                <p className="text-sm text-gray-500">includes image tokens</p>
+            )}
         </div>
         <div className="space-y-1">
             <h2 className="font-black leading-none">Characters</h2>
             <p className="text-4xl font-thin">{chars}</p>
+            <p className="text-sm text-gray-500">text only</p>
         </div>
     </div>
 );

--- a/components/tokenComponents.tsx
+++ b/components/tokenComponents.tsx
@@ -153,18 +153,18 @@ export const TokenizerInput = () => {
     return (
         <>
             <div className="space-y-4 mb-4">
-                <Textarea
-                    placeholder="Enter some text"
-                    rows={10}
-                    className="font-mono"
-                    value={text}
-                    onChange={(e) => setText(e.target.value)}
-                />
-            </div>
-            {error && <p className="text-red-500 mb-4">{error}</p>}
-            <TokenMetrics tokens={stats.tokens ?? 0} chars={stats.chars} />
-        
-            
+                {/* Text Input */}
+                <div>
+                    <label className="block text-sm font-medium mb-2">Text Input</label>
+                    <Textarea
+                        placeholder="Enter some text"
+                        rows={6}
+                        className="font-mono"
+                        value={text}
+                        onChange={(e) => setText(e.target.value)}
+                    />
+                </div>
+
                 {/* Image Input */}
                 <div>
                     <label className="block text-sm font-medium mb-2">Image Input</label>

--- a/components/tokenComponents.tsx
+++ b/components/tokenComponents.tsx
@@ -19,8 +19,25 @@ interface InputData {
 
 export const TokenizerInput = () => {
     const [text, setText] = useState('');
+    const [image, setImage] = useState<File | null>(null);
+    const [imagePreview, setImagePreview] = useState<string | null>(null);
     const [stats, setStats] = useState<{ tokens: number | null; chars: number }>({ tokens: null, chars: 0 });
     const [error, setError] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const convertImageToBase64 = (file: File): Promise<string> => {
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => {
+                const result = reader.result as string;
+                // Remove the data URL prefix (e.g., "data:image/jpeg;base64,")
+                const base64 = result.split(',')[1];
+                resolve(base64);
+            };
+            reader.onerror = reject;
+            reader.readAsDataURL(file);
+        });
+    };
 
     const handleAnalyze = async (text: string) => {
         if (!text.trim()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.462.0",
-        "next": "14.2.16",
+        "next": "^14.2.31",
         "react": "^18",
         "react-dom": "^18",
         "tailwind-merge": "^2.5.5",
@@ -249,9 +249,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.16",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.16.tgz",
-      "integrity": "sha512-fLrX5TfJzHCbnZ9YUSnGW63tMV3L4nSfhgOQ0iCcX21Pt+VSTDuaLsSuL8J/2XAiVA5AnzvXDpf6pMs60QxOag=="
+      "version": "14.2.31",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.31.tgz",
+      "integrity": "sha512-X8VxxYL6VuezrG82h0pUA1V+DuTSJp7Nv15bxq3ivrFqZLjx81rfeHMWOE9T0jm1n3DtHGv8gdn6B0T0kr0D3Q=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.2.16",
@@ -263,9 +263,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.16.tgz",
-      "integrity": "sha512-uFT34QojYkf0+nn6MEZ4gIWQ5aqGF11uIZ1HSxG+cSbj+Mg3+tYm8qXYd3dKN5jqKUm5rBVvf1PBRO/MeQ6rxw==",
+      "version": "14.2.31",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.31.tgz",
+      "integrity": "sha512-dTHKfaFO/xMJ3kzhXYgf64VtV6MMwDs2viedDOdP+ezd0zWMOQZkxcwOfdcQeQCpouTr9b+xOqMCUXxgLizl8Q==",
       "cpu": [
         "arm64"
       ],
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.16.tgz",
-      "integrity": "sha512-mCecsFkYezem0QiZlg2bau3Xul77VxUD38b/auAjohMA22G9KTJneUYMv78vWoCCFkleFAhY1NIvbyjj1ncG9g==",
+      "version": "14.2.31",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.31.tgz",
+      "integrity": "sha512-iSavebQgeMukUAfjfW8Fi2Iz01t95yxRl2w2wCzjD91h5In9la99QIDKcKSYPfqLjCgwz3JpIWxLG6LM/sxL4g==",
       "cpu": [
         "x64"
       ],
@@ -293,9 +293,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.16.tgz",
-      "integrity": "sha512-yhkNA36+ECTC91KSyZcgWgKrYIyDnXZj8PqtJ+c2pMvj45xf7y/HrgI17hLdrcYamLfVt7pBaJUMxADtPaczHA==",
+      "version": "14.2.31",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.31.tgz",
+      "integrity": "sha512-XJb3/LURg1u1SdQoopG6jDL2otxGKChH2UYnUTcby4izjM0il7ylBY5TIA7myhvHj9lG5pn9F2nR2s3i8X9awQ==",
       "cpu": [
         "arm64"
       ],
@@ -308,9 +308,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.16.tgz",
-      "integrity": "sha512-X2YSyu5RMys8R2lA0yLMCOCtqFOoLxrq2YbazFvcPOE4i/isubYjkh+JCpRmqYfEuCVltvlo+oGfj/b5T2pKUA==",
+      "version": "14.2.31",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.31.tgz",
+      "integrity": "sha512-IInDAcchNCu3BzocdqdCv1bKCmUVO/bKJHnBFTeq3svfaWpOPewaLJ2Lu3GL4yV76c/86ZvpBbG/JJ1lVIs5MA==",
       "cpu": [
         "arm64"
       ],
@@ -323,9 +323,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.16.tgz",
-      "integrity": "sha512-9AGcX7VAkGbc5zTSa+bjQ757tkjr6C/pKS7OK8cX7QEiK6MHIIezBLcQ7gQqbDW2k5yaqba2aDtaBeyyZh1i6Q==",
+      "version": "14.2.31",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.31.tgz",
+      "integrity": "sha512-YTChJL5/9e4NXPKW+OJzsQa42RiWUNbE+k+ReHvA+lwXk+bvzTsVQboNcezWOuCD+p/J+ntxKOB/81o0MenBhw==",
       "cpu": [
         "x64"
       ],
@@ -338,9 +338,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.16.tgz",
-      "integrity": "sha512-Klgeagrdun4WWDaOizdbtIIm8khUDQJ/5cRzdpXHfkbY91LxBXeejL4kbZBrpR/nmgRrQvmz4l3OtttNVkz2Sg==",
+      "version": "14.2.31",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.31.tgz",
+      "integrity": "sha512-A0JmD1y4q/9ufOGEAhoa60Sof++X10PEoiWOH0gZ2isufWZeV03NnyRlRmJpRQWGIbRkJUmBo9I3Qz5C10vx4w==",
       "cpu": [
         "x64"
       ],
@@ -353,9 +353,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.16.tgz",
-      "integrity": "sha512-PwW8A1UC1Y0xIm83G3yFGPiOBftJK4zukTmk7DI1CebyMOoaVpd8aSy7K6GhobzhkjYvqS/QmzcfsWG2Dwizdg==",
+      "version": "14.2.31",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.31.tgz",
+      "integrity": "sha512-nowJ5GbMeDOMzbTm29YqrdrD6lTM8qn2wnZfGpYMY7SZODYYpaJHH1FJXE1l1zWICHR+WfIMytlTDBHu10jb8A==",
       "cpu": [
         "arm64"
       ],
@@ -368,9 +368,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.16.tgz",
-      "integrity": "sha512-jhPl3nN0oKEshJBNDAo0etGMzv0j3q3VYorTSFqH1o3rwv1MQRdor27u1zhkgsHPNeY1jxcgyx1ZsCkDD1IHgg==",
+      "version": "14.2.31",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.31.tgz",
+      "integrity": "sha512-pk9Bu4K0015anTS1OS9d/SpS0UtRObC+xe93fwnm7Gvqbv/W1ZbzhK4nvc96RURIQOux3P/bBH316xz8wjGSsA==",
       "cpu": [
         "ia32"
       ],
@@ -383,9 +383,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.16.tgz",
-      "integrity": "sha512-OA7NtfxgirCjfqt+02BqxC3MIgM/JaGjw9tOe4fyZgPsqfseNiMPnCRP44Pfs+Gpo9zPN+SXaFsgP6vk8d571A==",
+      "version": "14.2.31",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.31.tgz",
+      "integrity": "sha512-LwFZd4JFnMHGceItR9+jtlMm8lGLU/IPkgjBBgYmdYSfalbHCiDpjMYtgDQ2wtwiAOSJOCyFI4m8PikrsDyA6Q==",
       "cpu": [
         "x64"
       ],
@@ -727,9 +727,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1179,9 +1179,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1227,6 +1227,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -1554,6 +1566,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1638,13 +1663,9 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "engines": {
         "node": ">= 0.4"
       }
@@ -1653,7 +1674,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -1685,10 +1705,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
-      "dev": true,
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -1697,14 +1716,14 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2317,12 +2336,14 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -2401,22 +2422,38 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "dev": true,
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-symbol-description": {
@@ -2481,9 +2518,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2534,12 +2571,11 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2599,10 +2635,9 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2614,7 +2649,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -3306,6 +3340,14 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3413,11 +3455,11 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "14.2.16",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.16.tgz",
-      "integrity": "sha512-LcO7WnFu6lYSvCzZoo1dB+IO0xXz5uEv52HF1IUN0IqVTUIZGHuuR10I5efiLadGt+4oZqTcNZyVVEem/TM5nA==",
+      "version": "14.2.31",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.31.tgz",
+      "integrity": "sha512-Wyw1m4t8PhqG+or5a1U/Deb888YApC4rAez9bGhHkTsfwAy4SWKVro0GhEx4sox1856IbLhvhce2hAA6o8vkog==",
       "dependencies": {
-        "@next/env": "14.2.16",
+        "@next/env": "14.2.31",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -3432,15 +3474,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.16",
-        "@next/swc-darwin-x64": "14.2.16",
-        "@next/swc-linux-arm64-gnu": "14.2.16",
-        "@next/swc-linux-arm64-musl": "14.2.16",
-        "@next/swc-linux-x64-gnu": "14.2.16",
-        "@next/swc-linux-x64-musl": "14.2.16",
-        "@next/swc-win32-arm64-msvc": "14.2.16",
-        "@next/swc-win32-ia32-msvc": "14.2.16",
-        "@next/swc-win32-x64-msvc": "14.2.16"
+        "@next/swc-darwin-arm64": "14.2.31",
+        "@next/swc-darwin-x64": "14.2.31",
+        "@next/swc-linux-arm64-gnu": "14.2.31",
+        "@next/swc-linux-arm64-musl": "14.2.31",
+        "@next/swc-linux-x64-gnu": "14.2.31",
+        "@next/swc-linux-x64-musl": "14.2.31",
+        "@next/swc-win32-arm64-msvc": "14.2.31",
+        "@next/swc-win32-ia32-msvc": "14.2.31",
+        "@next/swc-win32-x64-msvc": "14.2.31"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.462.0",
-    "next": "14.2.16",
+    "next": "^14.2.31",
     "react": "^18",
     "react-dom": "^18",
     "tailwind-merge": "^2.5.5",


### PR DESCRIPTION
Add image input support to tokenizer
Extends the existing text tokenizer to handle image uploads alongside text input.

**Changes:**

- Add image file input with preview and validation
- Call separate /api/image endpoint for image token counting
- Combine text + image token counts when both are provided
- Support PNG, JPEG, WebP formats (10MB max)
- Enhanced error handling and loading states

**UI Updates:**

- Separate labeled sections for text and image input
- Image preview with remove functionality
- Updated token metrics to indicate when image tokens are included